### PR TITLE
Update Blackhole.swift to use @_optimize(none) instead of @inline(never)

### DIFF
--- a/Sources/CollectionsBenchmark/Basics/Blackhole.swift
+++ b/Sources/CollectionsBenchmark/Basics/Blackhole.swift
@@ -15,6 +15,6 @@
 /// get used, and this could potentially interfere with the accuracy of a
 /// benchmark. To defeat these optimizations, pass such unused results to
 /// this function so that the compiler considers them used.
-@inline(never)
+@_optimize(none)
 public func blackHole<T>(_ value: T) {
 }

--- a/Sources/CollectionsBenchmark/Basics/Identity.swift
+++ b/Sources/CollectionsBenchmark/Basics/Identity.swift
@@ -17,7 +17,7 @@
 /// To defeat these optimizations, pass such constant input values to this
 /// function; the compiler won't be able to tell that the function doesn't
 /// actually do anything, so the optimizations won't trigger.
-@inline(never)
+@_optimize(none)
 public func identity<T>(_ value: T) -> T {
   value
 }


### PR DESCRIPTION
The new default CMO in Swift 5.8 breaks the current blackHole so most likely should fix this one up too.

Background:

https://github.com/apple/swift/commit/1fceeab71e79dc96f1b6f560bf745b016d7fcdcf 
https://github.com/ordo-one/package-benchmark/pull/179 
https://forums.swift.org/t/brave-new-world-best-practices-for-cross-module-optimization/66869/3

Replace this paragraph with a description of your changes and rationale. Provide links to an existing issue or external references/discussions, if appropriate.

### Checklist
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-collections-benchmark#contributing-to-swift-collections-benchmark)
- [x] My contributions are licensed under the [Swift license](https://swift.org/LICENSE.txt).
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering my changes (if appropriate).
- [x] I've verified that my change compiles and works correctly, and does not break any existing tests.
- [ ] I've updated the documentation (if appropriate).
